### PR TITLE
feat: add read/done/unsub dunst actions

### DIFF
--- a/gh-notify-desktop
+++ b/gh-notify-desktop
@@ -233,9 +233,9 @@ notify_with_dunst() {
         dunstify "[$repo_slug] $type: $reason" "$title" -a "gh-notify-desktop" \
             ${ICON:+-i "$ICON"} \
             -A "web,open in browser" \
-            -A "read,mark thread as read" \
-            -A "done,mark thread as done" \
-            -A "unsub,unsubscribe from thread" \
+            -A "read,mark as read" \
+            -A "done,mark as done" \
+            -A "unsub,unsubscribe" \
             ${cli_action:+-A "$cli_action"}
     )
 

--- a/gh-notify-desktop
+++ b/gh-notify-desktop
@@ -73,7 +73,10 @@ check_poll_interval() {
 }
 
 gh_rest_api() {
-    command gh api --header "X-GitHub-Api-Version: 2022-11-28" "$@"
+    command gh api \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "$@"
 }
 
 check_response_headers() {
@@ -81,9 +84,7 @@ check_response_headers() {
 
     resp="$(
         # jq expression adopted from https://github.com/meiji163/gh-notify
-        gh api -i "/notifications?participating=$PARTICIPATING&all=$ALL" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
+        gh_rest_api -i "/notifications?participating=$PARTICIPATING&all=$ALL" \
             -H "If-Modified-Since: $(
                 [ -z "$DEBUG" ] && cat "$DATA_DIR/last-modified" 2>/dev/null
             )" \
@@ -145,7 +146,7 @@ check_response_headers() {
 # Processes a page of GitHub notifications, extracting and formatting relevant details.
 process_page() {
     local page="$1" unhashed_number number=""
-    while IFS=$'\t' read -r _ _ comment_number repo_slug type url reason title; do
+    while IFS=$'\t' read -r thread_id thread_state comment_number repo_slug type url reason title; do
         if ! command grep -q "^null" <<<"$url"; then
             if ! output=$(process_url "$type" "$url"); then
                 return 1
@@ -156,7 +157,7 @@ process_page() {
             fi
         fi
 
-        notify_with_dunst "$comment_number" "$repo_slug" \
+        notify_with_dunst "$thread_id" "$thread_state" "$comment_number" "$repo_slug" \
             "${modified_type:-$type}" "$number" "$reason" "$title" &
     done <<<"$page"
 }
@@ -186,7 +187,7 @@ process_url() {
 }
 
 open_in_browser() {
-    local unhashed_number comment_number="$1" repo_slug="$2" type="$3" number="$4"
+    local unhashed_number thread_id="$1" thread_state="$2" comment_number="$1" repo_slug="$2" type="$3" number="$4"
     unhashed_number=$(command tr -d "#" <<<"$number")
     case "$type" in
         CheckSuite)
@@ -217,8 +218,8 @@ open_in_browser() {
 }
 
 notify_with_dunst() {
-    local cli_action action_response flags \
-        comment_number="$1" repo_slug="$2" type="$3" number="$4" reason="$5" title="$6"
+    local cli_action action_response flags thread_id="$1" thread_state="$2" \
+        comment_number="$3" repo_slug="$4" type="$5" number="$6" reason="$7" title="$8"
 
     # Add dunstify action to open if the gh-notify extension is installed
     # and if the TERMINAL environment variable is set to a supported emulator
@@ -232,10 +233,22 @@ notify_with_dunst() {
         dunstify "[$repo_slug] $type: $reason" "$title" -a "gh-notify-desktop" \
             ${ICON:+-i "$ICON"} \
             -A "web,open in browser" \
+            -A "read,mark thread as read" \
+            -A "done,mark thread as done" \
+            -A "unsub,unsubscribe from thread" \
             ${cli_action:+-A "$cli_action"}
     )
 
     case "$action_response" in
+        read)
+            gh_rest_api --method PATCH "/notifications/threads/$thread_id"
+            ;;
+        done)
+            gh_rest_api --method DELETE "/notifications/threads/$thread_id"
+            ;;
+        unsub)
+            gh_rest_api --method DELETE "/notifications/threads/$thread_id/subscription"
+            ;;
         web)
             open_in_browser "$comment_number" "$repo_slug" "$type" "$number"
             ;;


### PR DESCRIPTION
Add dunst action for unsubscribing to a thread, or marking it as read or done.

BEGIN_COMMIT_OVERRIDE
feat: add dunst actions to mark the notification as `read`, `done`, or `unsubscribed`
END_COMMIT_OVERRIDE
