### PR TITLE
fix: resolve duplicate notifications being generated

### DIFF
--- a/gh-notify-desktop
+++ b/gh-notify-desktop
@@ -274,4 +274,3 @@ shift "$((OPTIND - 1))"
 
 [ -z "$DEBUG" ] && check_poll_interval
 check_response_headers
-process_page "$body"


### PR DESCRIPTION
Two desktop notifications were being generated per GitHub notification. It took me a while to realize since I stack duplicate notifications via dunst

BEGIN_COMMIT_OVERRIDE
fix: resolve issue that caused duplicate notifications to be displayed
END_COMMIT_OVERRIDE