### PR TITLE
feat: add option for max notifications to show at once

### DIFF
--- a/gh-notify-desktop
+++ b/gh-notify-desktop
@@ -27,6 +27,10 @@ elif [ -f "$EXTENSION_DIR/img/github-mark-white.svg" ]; then
     ICON="$EXTENSION_DIR/img/github-mark-white.svg"
 fi
 
+if ! [[ $GH_ND_MAX =~ ^[0-9]+$ ]] || [[ $GH_ND_MAX -gt 50 ]]; then
+    GH_ND_MAX=50
+fi
+
 PARTICIPATING=false
 ALL=false
 
@@ -137,7 +141,12 @@ check_response_headers() {
         echo "There are new GitHub notifications" >&2
         # don't create a desktop notification if the io streams are a tty
         [ -z "$DEBUG" ] && [ -t 0 ] && [ -t 1 ] && exit 0
-        process_page "$body"
+        # don't spam user with a bunch of notifications
+        if [ "$(wc -l <<<"$body")" -ge $GH_ND_MAX ]; then
+            notify_max_with_dunst
+        else
+            process_page "$body"
+        fi
     elif [ "$status_code" = "304" ]; then
         echo "Up to date on GitHub notifications" >&2
         exit 2
@@ -221,9 +230,8 @@ open_in_browser() {
     esac
 }
 
-notify_with_dunst() {
-    local cli_action action_response flags thread_id="$1" thread_state="$2" \
-        comment_number="$3" repo_slug="$4" type="$5" number="$6" reason="$7" title="$8"
+notify_max_with_dunst() {
+    local cli_action action_response flags="" query=""
 
     # Add dunstify action to open if the gh-notify extension is installed
     # and if the TERMINAL environment variable is set to a supported emulator
@@ -234,33 +242,48 @@ notify_with_dunst() {
     fi
 
     action_response=$(
+        dunstify "GitHub Notifications" "There are ${GH_ND_MAX}+ new GitHub notifications" \
+            -a "gh-notify-desktop" \
+            ${ICON:+-i "$ICON"} \
+            -A "web,open in browser" \
+            ${cli_action:+-A "$cli_action"}
+    )
+
+    if [ "$PARTICIPATING" = true ]; then
+        query+="reason%3Aparticipating&"
+        flags+=" -p"
+    fi
+
+    if [ "$ALL" = false ]; then
+        query+="is%3Aunread"
+    else
+        flags+=" -a"
+    fi
+
+    case "$action_response" in
+        web) ${GH_ND_OPEN_CMD} "https://github.com/notifications?query=$query" ;;
+        cli) $TERMINAL -e sh -c "gh notify$flags" ;;
+    esac
+}
+
+notify_with_dunst() {
+    local cli_action action_response flags thread_id="$1" thread_state="$2" \
+        comment_number="$3" repo_slug="$4" type="$5" number="$6" reason="$7" title="$8"
+
+    action_response=$(
         dunstify "[$repo_slug] $type: $reason" "$title" -a "gh-notify-desktop" \
             ${ICON:+-i "$ICON"} \
             -A "web,open in browser" \
             -A "read,mark as read" \
             -A "done,mark as done" \
-            -A "unsub,unsubscribe" \
-            ${cli_action:+-A "$cli_action"}
+            -A "unsub,unsubscribe"
     )
 
     case "$action_response" in
-        read)
-            gh_rest_api --method PATCH "/notifications/threads/$thread_id"
-            ;;
-        done)
-            gh_rest_api --method DELETE "/notifications/threads/$thread_id"
-            ;;
-        unsub)
-            gh_rest_api --method DELETE "/notifications/threads/$thread_id/subscription"
-            ;;
-        web)
-            open_in_browser "$comment_number" "$repo_slug" "$type" "$number"
-            ;;
-        cli)
-            [ "$PARTICIPATING" = true ] && flags+=" -p"
-            [ "$ALL" = true ] && flags+=" -a"
-            $TERMINAL -e sh -c "gh notify$flags"
-            ;;
+        web) open_in_browser "$comment_number" "$repo_slug" "$type" "$number" ;;
+        read) gh_rest_api --method PATCH "/notifications/threads/$thread_id" ;;
+        done) gh_rest_api --method DELETE "/notifications/threads/$thread_id" ;;
+        unsub) gh_rest_api --method DELETE "/notifications/threads/$thread_id/subscription" ;;
     esac
 }
 

--- a/gh-notify-desktop
+++ b/gh-notify-desktop
@@ -85,7 +85,7 @@ check_poll_interval() {
     echo "$now" >"$DATA_DIR/last-checked"
 }
 
-check_response_headers() {
+get_notifications() {
     local headers status_code last_modified poll_interval
 
     resp="$(
@@ -106,7 +106,7 @@ check_response_headers() {
             } | [
             .thread_id, .thread_state, .comment_number,
             .repo_slug, .type, .url, .reason, .title
-        ] | @tsv' 2>"$DATA_DIR/log"
+        ] | @tsv' 2>>"$DATA_DIR/log"
     )"
 
     [ -n "$DEBUG" ] && echo "$resp"
@@ -137,23 +137,38 @@ check_response_headers() {
         echo "$poll_interval" >"$DATA_DIR/poll-interval"
     fi
 
-    if [ "$status_code" = "200" ]; then
-        echo "There are new GitHub notifications" >&2
-        # don't create a desktop notification if the io streams are a tty
-        [ -z "$DEBUG" ] && [ -t 0 ] && [ -t 1 ] && exit 0
-        # don't spam user with a bunch of notifications
-        if [ "$(wc -l <<<"$body")" -ge $GH_ND_MAX ]; then
-            notify_max_with_dunst
-        else
-            process_page "$body"
-        fi
-    elif [ "$status_code" = "304" ]; then
-        echo "Up to date on GitHub notifications" >&2
-        exit 2
-    else
-        echo "GitHub responded with status code $status_code" >&2
-        exit 1
-    fi
+    case $status_code in
+        200)
+            # don't create a desktop notification if the io streams are a tty
+            if [ -z "$DEBUG" ] && [ -t 0 ] && [ -t 1 ]; then
+                echo "$body"
+                exit 0
+            fi
+
+            # show one notification if the count is more than the specified max
+            if [[ $(wc -l <<<"$body") -ge $GH_ND_MAX ]]; then
+                dunst_notify_max &
+            # otherwise, create a desktop notification per github notification
+            else
+                process_page "$body"
+            fi
+            ;;
+        304)
+            echo "Up to date on GitHub notifications" >&2
+            exit 3
+            ;;
+        401)
+            printf '%s\n' \
+                'Error: Requires authentication.' \
+                'Ensure the gh token has notifications privileges:' \
+                '$ gh auth refresh -h github.com -s notifications' >&2
+            exit 4
+            ;;
+        *)
+            echo "GitHub responded with status code $status_code" >&2
+            exit 2
+            ;;
+    esac
 }
 
 # Processes a page of GitHub notifications, extracting and formatting relevant details.
@@ -170,7 +185,7 @@ process_page() {
             fi
         fi
 
-        notify_with_dunst "$thread_id" "$thread_state" "$comment_number" "$repo_slug" \
+        dunst_notify_thread "$thread_id" "$thread_state" "$comment_number" "$repo_slug" \
             "${modified_type:-$type}" "$number" "$reason" "$title" &
     done <<<"$page"
 }
@@ -230,7 +245,7 @@ open_in_browser() {
     esac
 }
 
-notify_max_with_dunst() {
+dunst_notify_max() {
     local cli_action action_response flags="" query=""
 
     # Add dunstify action to open if the gh-notify extension is installed
@@ -266,7 +281,7 @@ notify_max_with_dunst() {
     esac
 }
 
-notify_with_dunst() {
+dunst_notify_thread() {
     local cli_action action_response flags thread_id="$1" thread_state="$2" \
         comment_number="$3" repo_slug="$4" type="$5" number="$6" reason="$7" title="$8"
 
@@ -300,4 +315,4 @@ done
 shift "$((OPTIND - 1))"
 
 [ -z "$DEBUG" ] && check_poll_interval
-check_response_headers
+get_notifications


### PR DESCRIPTION
Add the `GH_ND_MAX` environment variable, which specifies the most
individual notifications to show at once. The default is 50, which is
the amount returned by the gh api. Setting a value higher than 50 won't
do anything.

ref: https://docs.github.com/en/rest/activity/notifications?apiVersion=2022-11-28#list-notifications-for-the-authenticated-user

BEGIN_COMMIT_OVERRIDE
feat: add `GH_ND_MAX` environment variable to specify the max notifications to display at once
END_COMMIT_OVERRIDE