### PR TITLE
feat: add flags to get total count of unread notifications

### DIFF
--- a/gh-notify-desktop
+++ b/gh-notify-desktop
@@ -85,6 +85,21 @@ check_poll_interval() {
     echo "$now" >"$DATA_DIR/last-checked"
 }
 
+get_unread_notifications_count() {
+    local count
+
+    count="$(
+        gh_rest_api "/notifications?participating=$PARTICIPATING" \
+            --paginate --jq 'length' | awk '{s+=$1} END {print s}'
+    )"
+
+    [ -n "$DEBUG" ] && echo "unread notification count: $count" >&2
+
+    if [[ $count =~ ^[0-9]+$ ]]; then
+        echo "$count" >"$DATA_DIR/unread_count"
+    fi
+}
+
 get_notifications() {
     local headers status_code last_modified poll_interval
 
@@ -151,6 +166,11 @@ get_notifications() {
             # otherwise, create a desktop notification per github notification
             else
                 process_page "$body"
+            fi
+
+            # get the count of unread notifications for use in a statusbar
+            if [ -n "$COUNT_UNREAD" ]; then
+                get_unread_notifications_count
             fi
             ;;
         304)
@@ -302,10 +322,12 @@ dunst_notify_thread() {
     esac
 }
 
-while getopts i:aph opt; do
+while getopts i:Ccaph opt; do
     case $opt in
         a) ALL=true ;;
         p) PARTICIPATING=true ;;
+        c) COUNT_UNREAD=true ;;
+        C) ONLY_COUNT_UNREAD=true ;;
         i) [ -f "$OPTARG" ] && ICON="$OPTARG" ;;
         h) die ;;
         *) die ;;
@@ -313,6 +335,12 @@ while getopts i:aph opt; do
 done
 
 shift "$((OPTIND - 1))"
+
+if [ -n "$ONLY_COUNT_UNREAD" ]; then
+    get_unread_notifications_count
+    cat "$DATA_DIR/unread_count"
+    exit 0
+fi
 
 [ -z "$DEBUG" ] && check_poll_interval
 get_notifications


### PR DESCRIPTION
The count is saved to a file named `unread_count` in the directory specified by the `$GH_ND_DATA_DIR` environment variable, which defaults to: `~/.local/state/gh-notify-desktop/`

The `-c` flag respects GitHub's Last-Modified header, meaning it will only fetch the count when the user receives new notifications. This means the actual count can be less than the saved number if you've read notifications since you received a new one. However, the actual count will never be larger.

The `-C` flag ignores GitHub's polling headers when fetching the count, so it will always be correct. The flag also skips displaying any new desktop notifications. The count is printed to stdout in addition to being saved in the `unread_count` file.

BEGIN_COMMIT_OVERRIDE
feat: add `-c` and `-C` flags that get the total count of unread notifications
END_COMMIT_OVERRIDE