### PR TITLE
feat: add support for `osascript` and `notify-send`

### DIFF
--- a/gh-notify-desktop
+++ b/gh-notify-desktop
@@ -215,7 +215,7 @@ process_url() {
     fi
 }
 
-get_thread_url() {
+construct_url() {
     local unhashed_number thread_id="$1" thread_state="$2" comment_number="$1" repo_slug="$2" type="$3" number="$4"
     unhashed_number=$(command tr -d "#" <<<"$number")
     case "$type" in
@@ -246,14 +246,6 @@ get_thread_url() {
     esac
 }
 
-open_in_browser() {
-    local thread_url
-    thread_url=
-    if [ -n "$thread_url" ]; then
-        $GH_ND_OPEN_CMD "$(get_thread_url)"
-    fi
-}
-
 dunst_notify_max() {
     local cli_action action_response flags="" query=""
 
@@ -273,15 +265,28 @@ dunst_notify_max() {
             ${cli_action:+-A "$cli_action"}
     )
 
+    if [ "$PARTICIPATING" = true ]; then
+        query+="reason%3Aparticipating&"
+        flags+=" -p"
+    fi
+
+    if [ "$ALL" = false ]; then
+        query+="is%3Aunread"
+    else
+        flags+=" -a"
+    fi
+
     case "$action_response" in
-        web) ${GH_ND_OPEN_CMD} "$NOTIFICATIONS_URL" ;;
+        web) ${GH_ND_OPEN_CMD} "https://github.com/notifications?query=$query" ;;
         cli) $TERMINAL -e sh -c "gh notify$flags" ;;
     esac
 }
 
 notify_thread() {
-    local cli_action action_response flags thread_id="$1" thread_state="$2" \
+    local cli_action action_response flags url thread_id="$1" thread_state="$2" \
         comment_number="$3" repo_slug="$4" type="$5" number="$6" reason="$7" title="$8"
+
+    url="$(construct_url "$comment_number" "$repo_slug" "$type" "$number")"
 
     if _has dunstify; then
         action_response=$(
@@ -293,16 +298,16 @@ notify_thread() {
                 -A "unsub,unsubscribe"
         )
         case "$action_response" in
-            web) ${GH_ND_OPEN_CMD} "$(get_thread_url "$comment_number" "$repo_slug" "$type" "$number")" ;;
+            web) ${GH_ND_OPEN_CMD} "${url}" ;;
             read) gh_rest_api --method PATCH "/notifications/threads/$thread_id" ;;
             done) gh_rest_api --method DELETE "/notifications/threads/$thread_id" ;;
             unsub) gh_rest_api --method DELETE "/notifications/threads/$thread_id/subscription" ;;
         esac
     elif _has notify-send; then
-        notify-send "[$repo_slug] $type: $reason" "$title\n$NOTIFICATIONS_URL" \
+        notify-send "[$repo_slug] $type: $reason" "$title\n\n${url}" \
             -a "gh-notify-desktop" ${ICON:+-i "$ICON"}
     elif _has osascript; then
-        osascript -e "display notification \"$title\n$NOTIFICATIONS_URL\" with title \"[$repo_slug] $type: $reason\""
+        osascript -e "display notification \"$title\n\n$url\" with title \"[$repo_slug] $type: $reason\""
     else
         die "notification support not found." \
             "Supports: dunstify, notify-send, osascript"
@@ -320,19 +325,6 @@ while getopts i:aph opt; do
 done
 
 shift "$((OPTIND - 1))"
-
-if [ "$PARTICIPATING" = true ]; then
-    query+="reason%3Aparticipating&"
-    flags+=" -p"
-fi
-
-if [ "$ALL" = false ]; then
-    query+="is%3Aunread"
-else
-    flags+=" -a"
-fi
-
-NOTIFICATIONS_URL="https://github.com/notifications?query=$query"
 
 [ -z "$DEBUG" ] && check_poll_interval
 get_notifications

--- a/gh-notify-desktop
+++ b/gh-notify-desktop
@@ -163,7 +163,7 @@ get_notifications() {
 
             # show one notification if the count is more than the specified max
             if [[ $(wc -l <<<"$body") -ge $GH_ND_MAX ]]; then
-                dunst_notify_max &
+                notify_max &
             # otherwise, create a desktop notification per github notification
             else
                 process_page "$body"
@@ -266,55 +266,64 @@ construct_url() {
     esac
 }
 
-dunst_notify_max() {
-    local cli_action action_response terminal flags="" query=""
+notify_max() {
+    local title="GitHub Notifications"
+    local body="There are ${GH_ND_MAX}+ new GitHub notifications"
 
-    # Add dunstify action to open if the gh-notify extension is installed
-    # https://github.com/meiji163/gh-notify
-    if gh extension list 2>/dev/null | grep -q 'gh notify' 2>/dev/null; then
-        cli_action="cli,open in gh-notify"
+    if _has dunst; then
+        local cli_action action_response terminal flags="" query=""
 
-        # determine which terminal to use for opening gh-notify
-        if _has x-terminal-emulator; then
-            terminal=x-terminal-emulator
-        elif _has wezterm; then
-            terminal=wezterm
-        elif _has alacritty; then
-            terminal=alacritty
-        elif _has kitty; then
-            terminal=kitty
-        elif _has ghostty && [ "$(uname -s)" = "Linux" ]; then
-            terminal=ghostty
-        elif _has foot && [ "$XDG_SESSION_TYPE" = "wayland" ]; then
-            terminal=foot
-        else
-            unset cli_action
+        # Add dunstify action to open if the gh-notify extension is installed
+        # https://github.com/meiji163/gh-notify
+        if gh extension list 2>/dev/null | grep -q 'gh notify' 2>/dev/null; then
+            cli_action="cli,open in gh-notify"
+
+            # determine which terminal to use for opening gh-notify
+            if _has x-terminal-emulator; then
+                terminal=x-terminal-emulator
+            elif _has wezterm; then
+                terminal=wezterm
+            elif _has alacritty; then
+                terminal=alacritty
+            elif _has kitty; then
+                terminal=kitty
+            elif _has ghostty && [ "$(uname -s)" = "Linux" ]; then
+                terminal=ghostty
+            elif _has foot && [ "$XDG_SESSION_TYPE" = "wayland" ]; then
+                terminal=foot
+            else
+                unset cli_action
+            fi
         fi
-    fi
 
-    action_response=$(
-        dunstify "GitHub Notifications" "There are ${GH_ND_MAX}+ new GitHub notifications" \
-            -a "gh-notify-desktop" \
-            ${ICON:+-i "$ICON"} \
-            -A "web,open in browser" \
-            ${cli_action:+-A "$cli_action"}
-    )
+        action_response=$(
+            dunstify "$title" "$body" -a "gh-notify-desktop" ${ICON:+-i "$ICON"} \
+                -A "web,open in browser" ${cli_action:+-A "$cli_action"}
+        )
 
-    if [ "$PARTICIPATING" = true ]; then
-        query+="reason%3Aparticipating&"
-        flags+=" -p"
-    fi
+        if [ "$PARTICIPATING" = true ]; then
+            query+="reason%3Aparticipating&"
+            flags+=" -p"
+        fi
 
-    if [ "$ALL" = false ]; then
-        query+="is%3Aunread"
+        if [ "$ALL" = false ]; then
+            query+="is%3Aunread"
+        else
+            flags+=" -a"
+        fi
+
+        case "$action_response" in
+            web) ${GH_ND_OPEN_CMD} "https://github.com/notifications?query=$query" ;;
+            cli) $terminal -e sh -c "gh notify$flags" ;;
+        esac
+    elif _has notify-send; then
+        notify-send "$title" "$body" -a "gh-notify-desktop" ${ICON:+-i "$ICON"}
+    elif _has osascript; then
+        osascript -e "display notification \"$body\" with title \"$title\""
     else
-        flags+=" -a"
+        die "notification support not found." \
+            "Supports: dunstify, notify-send, osascript"
     fi
-
-    case "$action_response" in
-        web) ${GH_ND_OPEN_CMD} "https://github.com/notifications?query=$query" ;;
-        cli) $terminal -e sh -c "gh notify$flags" ;;
-    esac
 }
 
 notify_thread() {

--- a/gh-notify-desktop
+++ b/gh-notify-desktop
@@ -333,11 +333,11 @@ notify_thread() {
     url="$(construct_url "$comment_number" "$repo_slug" "$type" "$number")"
 
     local notif_title="[$repo_slug] $type: $reason"
-    local notif_body="$title\n\n${url}"
+    local notif_body="$title\n${url}"
 
     if _has dunstify; then
         action_response=$(
-            dunstify "$notif_title" "$notif_body" -a "gh-notify-desktop" \
+            dunstify "$notif_title" "$title" -a "gh-notify-desktop" \
                 ${ICON:+-i "$ICON"} \
                 -A "web,open in browser" \
                 -A "read,mark as read" \

--- a/gh-notify-desktop
+++ b/gh-notify-desktop
@@ -270,7 +270,7 @@ notify_max() {
     local title="GitHub Notifications"
     local body="There are ${GH_ND_MAX}+ new GitHub notifications"
 
-    if _has dunst; then
+    if _has dunstify; then
         local cli_action action_response terminal flags="" query=""
 
         # Add dunstify action to open if the gh-notify extension is installed
@@ -332,9 +332,12 @@ notify_thread() {
 
     url="$(construct_url "$comment_number" "$repo_slug" "$type" "$number")"
 
+    local notif_title="[$repo_slug] $type: $reason"
+    local notif_body="$title\n\n${url}"
+
     if _has dunstify; then
         action_response=$(
-            dunstify "[$repo_slug] $type: $reason" "$title\n$NOTIFICATIONS_URL" -a "gh-notify-desktop" \
+            dunstify "$notif_title" "$notif_body" -a "gh-notify-desktop" \
                 ${ICON:+-i "$ICON"} \
                 -A "web,open in browser" \
                 -A "read,mark as read" \
@@ -348,10 +351,10 @@ notify_thread() {
             unsub) gh_rest_api --method DELETE "/notifications/threads/$thread_id/subscription" ;;
         esac
     elif _has notify-send; then
-        notify-send "[$repo_slug] $type: $reason" "$title\n\n${url}" \
+        notify-send "$notif_title" "$notif_body" \
             -a "gh-notify-desktop" ${ICON:+-i "$ICON"}
     elif _has osascript; then
-        osascript -e "display notification \"$title\n\n$url\" with title \"[$repo_slug] $type: $reason\""
+        osascript -e "display notification \"$notif_body\" with title \"$notif_title\""
     else
         die "notification support not found." \
             "Supports: dunstify, notify-send, osascript"

--- a/gh-notify-desktop
+++ b/gh-notify-desktop
@@ -52,6 +52,7 @@ fi
 
 die() {
     echo "Something went wrong..." >&2
+    printf '%s/n' "$@"
     exit 1
 }
 
@@ -185,7 +186,7 @@ process_page() {
             fi
         fi
 
-        dunst_notify_thread "$thread_id" "$thread_state" "$comment_number" "$repo_slug" \
+        notify_thread "$thread_id" "$thread_state" "$comment_number" "$repo_slug" \
             "${modified_type:-$type}" "$number" "$reason" "$title" &
     done <<<"$page"
 }
@@ -214,35 +215,43 @@ process_url() {
     fi
 }
 
-open_in_browser() {
+get_thread_url() {
     local unhashed_number thread_id="$1" thread_state="$2" comment_number="$1" repo_slug="$2" type="$3" number="$4"
     unhashed_number=$(command tr -d "#" <<<"$number")
     case "$type" in
         CheckSuite)
-            $GH_ND_OPEN_CMD "https://github.com/${repo_slug}/actions" 2>/dev/null &
+            echo "https://github.com/${repo_slug}/actions"
             ;;
         Commit)
-            command gh browse "$number" --repo "$repo_slug"
+            echo "https://github.com/${repo_slug}/commit/${number}"
             ;;
         Discussion)
-            $GH_ND_OPEN_CMD "https://github.com/${repo_slug}/discussions/" 2>/dev/null &
+            echo "https://github.com/${repo_slug}/discussions/"
+            ;;
+        Pre-release | Release)
+            echo "https://github.com/${repo_slug}/releases/tag/${number}"
             ;;
         Issue | PullRequest)
             if [ -z "$comment_number" ] ||
                 [ "$comment_number" = "$unhashed_number" ] ||
                 [ "$comment_number" = "null" ]; then
-                command gh issue view "$number" --web --repo "$repo_slug"
+                echo "https://github.com/${repo_slug}/issues/${unhashed_number}"
             else
-                $GH_ND_OPEN_CMD "https://github.com/${repo_slug}/issues/${unhashed_number}#issuecomment-${comment_number}" 2>/dev/null &
+                echo "https://github.com/${repo_slug}/issues/${unhashed_number}#issuecomment-${comment_number}"
             fi
             ;;
-        Pre-release | Release)
-            command gh release view "$number" --web --repo "$repo_slug"
-            ;;
         *)
-            command gh repo view --web "$repo_slug"
+            echo "https://github.com/${repo_slug}"
             ;;
     esac
+}
+
+open_in_browser() {
+    local thread_url
+    thread_url=
+    if [ -n "$thread_url" ]; then
+        $GH_ND_OPEN_CMD "$(get_thread_url)"
+    fi
 }
 
 dunst_notify_max() {
@@ -264,42 +273,40 @@ dunst_notify_max() {
             ${cli_action:+-A "$cli_action"}
     )
 
-    if [ "$PARTICIPATING" = true ]; then
-        query+="reason%3Aparticipating&"
-        flags+=" -p"
-    fi
-
-    if [ "$ALL" = false ]; then
-        query+="is%3Aunread"
-    else
-        flags+=" -a"
-    fi
-
     case "$action_response" in
-        web) ${GH_ND_OPEN_CMD} "https://github.com/notifications?query=$query" ;;
+        web) ${GH_ND_OPEN_CMD} "$NOTIFICATIONS_URL" ;;
         cli) $TERMINAL -e sh -c "gh notify$flags" ;;
     esac
 }
 
-dunst_notify_thread() {
+notify_thread() {
     local cli_action action_response flags thread_id="$1" thread_state="$2" \
         comment_number="$3" repo_slug="$4" type="$5" number="$6" reason="$7" title="$8"
 
-    action_response=$(
-        dunstify "[$repo_slug] $type: $reason" "$title" -a "gh-notify-desktop" \
-            ${ICON:+-i "$ICON"} \
-            -A "web,open in browser" \
-            -A "read,mark as read" \
-            -A "done,mark as done" \
-            -A "unsub,unsubscribe"
-    )
-
-    case "$action_response" in
-        web) open_in_browser "$comment_number" "$repo_slug" "$type" "$number" ;;
-        read) gh_rest_api --method PATCH "/notifications/threads/$thread_id" ;;
-        done) gh_rest_api --method DELETE "/notifications/threads/$thread_id" ;;
-        unsub) gh_rest_api --method DELETE "/notifications/threads/$thread_id/subscription" ;;
-    esac
+    if _has dunstify; then
+        action_response=$(
+            dunstify "[$repo_slug] $type: $reason" "$title\n$NOTIFICATIONS_URL" -a "gh-notify-desktop" \
+                ${ICON:+-i "$ICON"} \
+                -A "web,open in browser" \
+                -A "read,mark as read" \
+                -A "done,mark as done" \
+                -A "unsub,unsubscribe"
+        )
+        case "$action_response" in
+            web) ${GH_ND_OPEN_CMD} "$(get_thread_url "$comment_number" "$repo_slug" "$type" "$number")" ;;
+            read) gh_rest_api --method PATCH "/notifications/threads/$thread_id" ;;
+            done) gh_rest_api --method DELETE "/notifications/threads/$thread_id" ;;
+            unsub) gh_rest_api --method DELETE "/notifications/threads/$thread_id/subscription" ;;
+        esac
+    elif _has notify-send; then
+        notify-send "[$repo_slug] $type: $reason" "$title\n$NOTIFICATIONS_URL" \
+            -a "gh-notify-desktop" ${ICON:+-i "$ICON"}
+    elif _has osascript; then
+        osascript -e "display notification \"$title\n$NOTIFICATIONS_URL\" with title \"[$repo_slug] $type: $reason\""
+    else
+        die "notification support not found." \
+            "Supports: dunstify, notify-send, osascript"
+    fi
 }
 
 while getopts i:aph opt; do
@@ -313,6 +320,19 @@ while getopts i:aph opt; do
 done
 
 shift "$((OPTIND - 1))"
+
+if [ "$PARTICIPATING" = true ]; then
+    query+="reason%3Aparticipating&"
+    flags+=" -p"
+fi
+
+if [ "$ALL" = false ]; then
+    query+="is%3Aunread"
+else
+    flags+=" -a"
+fi
+
+NOTIFICATIONS_URL="https://github.com/notifications?query=$query"
 
 [ -z "$DEBUG" ] && check_poll_interval
 get_notifications


### PR DESCRIPTION
Add support for two more notification utilities: 
- `osascript` (for Mac)
- `notify-send` (for Linux)
